### PR TITLE
feat: map improvements + ScenarioLoader + bundled historical scenarios

### DIFF
--- a/assets/data/neobyzantine-locations.json
+++ b/assets/data/neobyzantine-locations.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0",
+  "note": "Placeholder — update by running `php artisan game:export --era=<year>` in neobyzantine-org and copying the resulting game-locations-<era>.json here.",
+  "exported_at": null,
+  "era": null,
+  "bounds": { "west": -15, "east": 92, "north": 60, "south": 5 },
+  "grid": { "width": 320, "height": 180 },
+  "locations": []
+}

--- a/assets/geography.js
+++ b/assets/geography.js
@@ -164,36 +164,73 @@ const LAND_POLYGONS = [
   [[49.5, 28.8], [51.8, 28.8], [51.8, 26.4], [49.5, 26.4]]     // Gulf coast land patch
 ];
 
+// Each river has id, name, width_class ('major'|'minor'), and path ([[lon,lat],...]).
+// major rivers render wider and require bridges for road crossings.
 const RIVER_PATHS = [
-  // Nile
-  [[31, 25], [31, 22], [31, 19], [32, 16], [33, 13]],
-  // Danube
-  [[9, 48], [14, 47], [19, 46], [24, 45], [29, 45]],
-  // Euphrates
-  [[38, 38], [40, 36], [42, 34], [44, 32]],
-  // Tigris
-  [[43, 38], [44, 36], [45, 34], [46, 31]],
-  // Po
-  [[8, 45], [10, 45], [12, 45]],
-  // Rhone
-  [[6, 46], [5, 44], [5, 43]],
-  // Dnieper
-  [[31, 52], [31, 49], [31, 46]]
+  { id: 'nile',      name: 'Nile',      width_class: 'major', path: [[31,25],[31,22],[31,19],[32,16],[33,13]] },
+  { id: 'danube',    name: 'Danube',    width_class: 'major', path: [[9,48],[14,47],[19,46],[24,45],[29,45]] },
+  { id: 'euphrates', name: 'Euphrates', width_class: 'major', path: [[38,38],[40,36],[42,34],[44,32]] },
+  { id: 'tigris',    name: 'Tigris',    width_class: 'major', path: [[43,38],[44,36],[45,34],[46,31]] },
+  { id: 'volga',     name: 'Volga',     width_class: 'major', path: [[49,57],[49,53],[50,48],[51,46]] },
+  { id: 'po',        name: 'Po',        width_class: 'minor', path: [[8,45],[10,45],[12,45]] },
+  { id: 'rhone',     name: 'Rhone',     width_class: 'minor', path: [[6,46],[5,44],[5,43]] },
+  { id: 'dnieper',   name: 'Dnieper',   width_class: 'minor', path: [[31,52],[31,49],[31,46]] },
+  { id: 'don',       name: 'Don',       width_class: 'minor', path: [[39,57],[40,54],[40,48]] },
+  { id: 'jordan',    name: 'Jordan',    width_class: 'minor', path: [[35,33],[35,32],[35,31]] },
+  { id: 'amu_darya', name: 'Amu Darya', width_class: 'minor', path: [[64,38],[62,38],[60,37]] },
+];
+
+// Major inland water bodies rendered as distinct lakes (not ocean).
+// These were geographically significant in the 500–1453 AD period.
+const LAKE_POLYGONS = [
+  { id: 'caspian',  name: 'Caspian Sea',
+    polygon: [[50,37],[51,38],[52,39],[53,40],[53,42],[52,43],[51,44],[50,43],[49,42],[49,40],[49,38]] },
+  { id: 'aral',     name: 'Aral Sea',
+    polygon: [[59,44],[61,44],[62,45],[61,46],[59,46],[58,45]] },
+  { id: 'van',      name: 'Lake Van',
+    polygon: [[43,38.5],[44,38.7],[43.5,38.9],[42.8,38.7]] },
+  { id: 'dead_sea', name: 'Dead Sea',
+    polygon: [[35.4,31.8],[35.6,31.6],[35.5,31.3],[35.3,31.5]] },
 ];
 
 function isNearRiver(lon, lat) {
   const riverWidthDeg = 0.30;
 
   for (const river of RIVER_PATHS) {
-    for (let i = 0; i < river.length - 1; i++) {
-      const [ax, ay] = river[i];
-      const [bx, by] = river[i + 1];
+    const path = river.path;
+    for (let i = 0; i < path.length - 1; i++) {
+      const [ax, ay] = path[i];
+      const [bx, by] = path[i + 1];
       if (distToSegment(lon, lat, ax, ay, bx, by) <= riverWidthDeg) {
         return true;
       }
     }
   }
 
+  return false;
+}
+
+function getRiverWidthClass(lon, lat) {
+  const riverWidthDeg = 0.30;
+
+  for (const river of RIVER_PATHS) {
+    const path = river.path;
+    for (let i = 0; i < path.length - 1; i++) {
+      const [ax, ay] = path[i];
+      const [bx, by] = path[i + 1];
+      if (distToSegment(lon, lat, ax, ay, bx, by) <= riverWidthDeg) {
+        return river.width_class;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isInLake(lon, lat) {
+  for (const lake of LAKE_POLYGONS) {
+    if (pointInPolygon(lon, lat, lake.polygon)) return true;
+  }
   return false;
 }
 
@@ -278,6 +315,12 @@ function generateWorldHeightmap() {
       // River carving for inland lowlands.
       if (isNearRiver(lon, lat) && elevation > 55 && elevation < 155) {
         elevation = Math.min(elevation, 48);
+      }
+
+      // Major inland water bodies: override elevation to shallow-water band (height 40).
+      // This makes Caspian, Aral, Lake Van, Dead Sea render as distinct inland lakes.
+      if (!inside && isInLake(lon, lat)) {
+        elevation = 40;
       }
 
       row.push(Math.floor(clamp(elevation, 0, 255)));

--- a/assets/scenarios/fall-of-constantinople-1453.json
+++ b/assets/scenarios/fall-of-constantinople-1453.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.0",
+  "id": "fall-of-constantinople-1453",
+  "title": "Fall of Constantinople (1453)",
+  "description": "Sultan Mehmed II lays siege to Constantinople with an army of 80,000–200,000 troops, a massive artillery train including the Basilica cannon, and a naval blockade. The last Byzantine Emperor, Constantine XI Palaiologos, falls defending the walls. After 1,123 years, the Eastern Roman Empire ends.",
+  "date_year": 1453,
+  "date_display": "May 29, 1453",
+  "century": "15",
+  "map_center": {
+    "lat": 41.01,
+    "lng": 28.97,
+    "tile_x": 146,
+    "tile_y": 68
+  },
+  "map_zoom": 4,
+  "forces": [
+    {
+      "faction": "byzantine",
+      "commander": "Constantine XI Palaiologos",
+      "actor_slug": "constantine-xi-palaiologos",
+      "position": {
+        "lat": 41.01,
+        "lng": 28.92,
+        "tile_x": 145,
+        "tile_y": 68
+      },
+      "units": ["infantry", "varangian_guard", "archers", "navy"],
+      "strength": "~7,000–10,000 defenders (incl. Genoese mercenaries)"
+    },
+    {
+      "faction": "seljuk",
+      "commander": "Mehmed II",
+      "actor_slug": "mehmed-ii",
+      "position": {
+        "lat": 41.01,
+        "lng": 29.05,
+        "tile_x": 147,
+        "tile_y": 68
+      },
+      "units": ["infantry", "heavy_cavalry", "siege", "horse_archers", "navy"],
+      "strength": "~80,000–200,000 (disputed)"
+    }
+  ],
+  "objectives": [
+    {
+      "location_id": "constantinople",
+      "name": "Constantinople",
+      "tile_x": 146,
+      "tile_y": 68,
+      "type": "capital"
+    }
+  ],
+  "historical_notes": "Constantine XI refused to surrender the city or flee. He died fighting on the walls alongside his soldiers on May 29, 1453. His body was never conclusively identified. The city was renamed Istanbul. The Orthodox Patriarchate remained in the city under Ottoman rule. The date is commemorated annually in Greece as a day of national mourning.",
+  "neobyzantine_event_url": "https://neobyzantine.org/timeline/fall-of-constantinople-1453",
+  "source": "bundled"
+}

--- a/assets/scenarios/manzikert-1071.json
+++ b/assets/scenarios/manzikert-1071.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.0",
+  "id": "manzikert-1071",
+  "title": "Battle of Manzikert (1071)",
+  "description": "The Seljuk Sultan Alp Arslan crushes the Byzantine army of Emperor Romanos IV Diogenes near the town of Manzikert (modern Malazgirt, Turkey). The Byzantine defeat opens Anatolia to Turkic settlement and marks the beginning of Byzantine decline in the East.",
+  "date_year": 1071,
+  "date_display": "August 26, 1071",
+  "century": "11",
+  "map_center": {
+    "lat": 39.05,
+    "lng": 42.87,
+    "tile_x": 176,
+    "tile_y": 73
+  },
+  "map_zoom": 5,
+  "forces": [
+    {
+      "faction": "byzantine",
+      "commander": "Romanos IV Diogenes",
+      "actor_slug": "romanos-iv-diogenes",
+      "position": {
+        "lat": 38.90,
+        "lng": 42.70,
+        "tile_x": 175,
+        "tile_y": 74
+      },
+      "units": ["heavy_cavalry", "tagmata", "archers", "varangian_guard", "infantry"],
+      "strength": "~40,000 (disputed)"
+    },
+    {
+      "faction": "seljuk",
+      "commander": "Alp Arslan",
+      "actor_slug": "alp-arslan",
+      "position": {
+        "lat": 39.20,
+        "lng": 43.05,
+        "tile_x": 177,
+        "tile_y": 72
+      },
+      "units": ["horse_archers", "heavy_cavalry"],
+      "strength": "~30,000–100,000 (disputed)"
+    }
+  ],
+  "objectives": [
+    {
+      "location_id": "manzikert",
+      "name": "Manzikert",
+      "tile_x": 176,
+      "tile_y": 73,
+      "type": "city"
+    }
+  ],
+  "historical_notes": "Romanos IV was captured during the battle — the first Byzantine emperor taken prisoner in centuries. The peace terms he negotiated were repudiated by the regency in Constantinople. Alp Arslan was assassinated shortly after. The battle is considered the turning point that made Anatolia permanently Turkic.",
+  "neobyzantine_event_url": "https://neobyzantine.org/timeline/battle-of-manzikert-1071",
+  "source": "bundled"
+}

--- a/index.html
+++ b/index.html
@@ -332,6 +332,7 @@
     <script src="js/leaders.js"></script>
     <script src="js/units.js"></script>
     <script src="js/mods.js"></script>
+    <script src="js/scenarios.js"></script>
     <script src="js/map.js"></script>
     <script src="js/minimap.js"></script>
     <script src="js/combat.js"></script>

--- a/js/map.js
+++ b/js/map.js
@@ -1169,30 +1169,52 @@ class GameMap {
 
     /**
      * Draw major river overlays on visible region.
+     * Major rivers (Nile, Danube, Euphrates, Tigris, Volga) render wider.
+     * Minor rivers render thin. Bridges drawn when road infrastructure is present.
      */
     drawRivers(startX, startY, endX, endY, tileSize) {
         if (typeof MEDITERRANEAN_HEIGHTMAP === 'undefined') return;
+        if (typeof getRiverWidthClass !== 'function') return;
 
-        this.ctx.strokeStyle = 'rgba(95, 175, 230, 0.65)';
         this.ctx.lineCap = 'round';
         this.ctx.lineJoin = 'round';
 
         for (let y = startY; y < endY; y++) {
             for (let x = startX; x < endX; x++) {
                 const height = MEDITERRANEAN_HEIGHTMAP[y]?.[x];
-                if (height === undefined || height > 50) continue;
+                if (height === undefined || height > 50 || height < 40) continue;
                 if (this.isFoggedTile(x, y)) continue;
 
-                // Draw river strokes only for inland water, not broad oceans.
-                if (height < 40) continue;
+                const geo = this.tileToGeo(x, y);
+                const widthClass = getRiverWidthClass(geo.lon, geo.lat);
+                if (!widthClass) continue;
 
                 const px = x * tileSize;
                 const py = y * tileSize;
-                this.ctx.lineWidth = Math.max(1, tileSize * 0.18);
+                const isMajor = widthClass === 'major';
+
+                // River stroke
+                this.ctx.strokeStyle = isMajor
+                    ? 'rgba(75, 155, 215, 0.75)'
+                    : 'rgba(95, 175, 230, 0.65)';
+                this.ctx.lineWidth = isMajor
+                    ? Math.max(2, tileSize * 0.38)
+                    : Math.max(1, tileSize * 0.18);
                 this.ctx.beginPath();
-                this.ctx.moveTo(px + tileSize * 0.15, py + tileSize * 0.5);
-                this.ctx.lineTo(px + tileSize * 0.85, py + tileSize * 0.5);
+                this.ctx.moveTo(px + tileSize * 0.1, py + tileSize * 0.5);
+                this.ctx.lineTo(px + tileSize * 0.9, py + tileSize * 0.5);
                 this.ctx.stroke();
+
+                // Bridge overlay: draw when tile has road infrastructure crossing a major river
+                const tile = this.tiles[y]?.[x];
+                if (isMajor && tile?.cityData?.infrastructure?.roads > 0) {
+                    this.ctx.strokeStyle = 'rgba(140, 120, 90, 0.9)';
+                    this.ctx.lineWidth = Math.max(2, tileSize * 0.14);
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(px + tileSize * 0.5, py + tileSize * 0.15);
+                    this.ctx.lineTo(px + tileSize * 0.5, py + tileSize * 0.85);
+                    this.ctx.stroke();
+                }
             }
         }
     }

--- a/js/scenarios.js
+++ b/js/scenarios.js
@@ -1,0 +1,235 @@
+'use strict';
+
+/**
+ * ScenarioLoader — loads historical battle scenarios from JSON.
+ *
+ * Scenarios can be bundled locally (assets/scenarios/*.json) or fetched
+ * from the neobyzantine-org Game Export API:
+ *   GET https://neobyzantine.org/api/game/scenario/{slug}
+ *
+ * JSON schema: docs/GAME_DATA_CONTRACT.md in neobyzantine-org repo (schema v1.0).
+ */
+class ScenarioLoader {
+    static SCHEMA_VERSION = '1.0';
+
+    // Allowed origins for remote scenario fetch (prevents SSRF-style abuse)
+    static ALLOWED_ORIGINS = [
+        'https://neobyzantine.org',
+        'http://localhost:8080',
+        'http://localhost',
+    ];
+
+    // Map scenario faction strings → 500ad faction ids
+    static FACTION_MAP = {
+        byzantine: 'byzantine',
+        roman: 'byzantine',
+        seljuk: 'arab',
+        ottoman: 'arab',
+        arab: 'arab',
+        sassanid: 'sassanid',
+        persian: 'sassanid',
+        frank: 'frank',
+        bulgar: 'bulgar',
+        slavic: 'bulgar',
+        neutral: 'byzantine',
+    };
+
+    // Map scenario unit strings → 500ad unit type ids
+    static UNIT_MAP = {
+        heavy_cavalry: 'cataphract',
+        tagmata: 'tagmata',
+        archers: 'archer',
+        varangian_guard: 'varangian',
+        horse_archers: 'horse_archer',
+        infantry: 'skutatoi',
+        siege: 'siege_engineer',
+        navy: 'transport_ship',
+    };
+
+    constructor() {
+        this._activeScenario = null;
+    }
+
+    // ── Loading ────────────────────────────────────────────────────────────
+
+    /**
+     * Fetch a scenario JSON from a remote URL.
+     * Only fetches from ALLOWED_ORIGINS for security.
+     */
+    async loadFromUrl(url) {
+        const origin = this._parseOrigin(url);
+        if (!origin || !ScenarioLoader.ALLOWED_ORIGINS.includes(origin)) {
+            throw new Error(`Scenario URL origin not allowed: ${origin}`);
+        }
+
+        const response = await fetch(url, { mode: 'cors' });
+        if (!response.ok) {
+            throw new Error(`Failed to fetch scenario: HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        return this._validate(data);
+    }
+
+    /** Parse and validate a scenario JSON string. */
+    loadFromJson(jsonString) {
+        let data;
+        try {
+            data = JSON.parse(jsonString);
+        } catch {
+            throw new Error('Scenario JSON is not valid JSON');
+        }
+        return this._validate(data);
+    }
+
+    /** Load a bundled scenario from assets/scenarios/{id}.json */
+    async loadBuiltin(scenarioId) {
+        const url = `assets/scenarios/${scenarioId}.json`;
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Built-in scenario not found: ${scenarioId}`);
+        }
+        const data = await response.json();
+        return this._validate(data);
+    }
+
+    // ── Applying ───────────────────────────────────────────────────────────
+
+    /**
+     * Apply a loaded GameScenario to the running game.
+     * Call after game init — places forces on tiles, sets camera.
+     */
+    applyScenario(gameState, gameMap, scenario) {
+        this._activeScenario = scenario;
+
+        // Center camera on scenario map_center
+        if (scenario.map_center) {
+            const { tile_x, tile_y } = scenario.map_center;
+            if (typeof tile_x === 'number' && typeof tile_y === 'number') {
+                gameMap.centerOn(tile_x, tile_y);
+            }
+        }
+
+        // Place each force on the map
+        for (const force of (scenario.forces || [])) {
+            this._placeForce(gameState, gameMap, force, scenario.date_year);
+        }
+
+        // Store metadata for UI display
+        gameState.activeScenario = {
+            id: scenario.id,
+            title: scenario.title,
+            dateYear: scenario.date_year,
+            dateDisplay: scenario.date_display,
+            neobyzantineUrl: scenario.neobyzantine_event_url,
+        };
+
+        console.info(`[ScenarioLoader] Applied scenario: ${scenario.title} (${scenario.date_year})`);
+    }
+
+    /**
+     * Merge GameMapExport locations into HISTORIC_TOWNS.
+     * Imported entries with the same id override hardcoded entries.
+     */
+    applyMapData(gameMap, mapExport) {
+        if (!mapExport.locations || !Array.isArray(mapExport.locations)) return;
+
+        const importedIds = new Set(mapExport.locations.map(l => l.id));
+
+        // Filter out overridden towns from hardcoded list
+        const baseList = (typeof HISTORIC_TOWNS !== 'undefined' ? HISTORIC_TOWNS : [])
+            .filter(t => !importedIds.has(t.id));
+
+        // Convert imported locations to 500ad town format
+        const importedTowns = mapExport.locations.map(loc => ({
+            id: loc.id,
+            name: loc.name,
+            x: loc.tile_x,
+            y: loc.tile_y,
+            lon: loc.lng,
+            lat: loc.lat,
+            type: loc.type === 'capital' ? 'capital' : loc.type === 'city' ? 'city' : 'town',
+            importance: loc.importance ?? 6,
+            cityData: {
+                kind: loc.type,
+                tribe: ScenarioLoader.FACTION_MAP[loc.faction] ?? 'byzantine',
+                historicalCivilization: ScenarioLoader.FACTION_MAP[loc.faction] ?? 'byzantine',
+            },
+        }));
+
+        // Merge: imported towns take precedence
+        gameMap.importedTowns = [...importedTowns, ...baseList];
+        console.info(`[ScenarioLoader] Imported ${importedTowns.length} locations from neobyzantine-org`);
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────────
+
+    getActiveScenario() {
+        return this._activeScenario;
+    }
+
+    clearActiveScenario() {
+        this._activeScenario = null;
+    }
+
+    // ── Internal ───────────────────────────────────────────────────────────
+
+    _validate(data) {
+        if (!data || typeof data !== 'object') {
+            throw new Error('Scenario must be a JSON object');
+        }
+        if (data.schema_version && data.schema_version !== ScenarioLoader.SCHEMA_VERSION) {
+            console.warn(`[ScenarioLoader] Schema version mismatch: got ${data.schema_version}, expected ${ScenarioLoader.SCHEMA_VERSION}`);
+        }
+        if (!data.id || typeof data.id !== 'string') {
+            throw new Error('Scenario must have a string "id" field');
+        }
+        if (!data.title || typeof data.title !== 'string') {
+            throw new Error('Scenario must have a string "title" field');
+        }
+        return data;
+    }
+
+    _placeForce(gameState, gameMap, force, era) {
+        const { tile_x, tile_y } = force.position || {};
+        if (typeof tile_x !== 'number' || typeof tile_y !== 'number') return;
+
+        const factionId = ScenarioLoader.FACTION_MAP[force.faction] ?? 'byzantine';
+        const isPlayer = factionId === 'byzantine' && gameState.playerFaction === 'byzantine';
+
+        const units = (force.units || ['infantry']).map(unitKey => {
+            const unitTypeId = ScenarioLoader.UNIT_MAP[unitKey] ?? 'skutatoi';
+            return {
+                type: unitTypeId,
+                x: tile_x,
+                y: tile_y,
+                owner: factionId,
+                health: 100,
+                fromScenario: true,
+            };
+        });
+
+        // Add units to gameState unit roster
+        if (typeof gameState.addUnits === 'function') {
+            gameState.addUnits(units);
+        } else if (Array.isArray(gameState.units)) {
+            gameState.units.push(...units);
+        }
+
+        console.info(`[ScenarioLoader] Placed ${units.length} ${factionId} unit(s) at tile (${tile_x}, ${tile_y})`);
+    }
+
+    _parseOrigin(url) {
+        try {
+            const u = new URL(url);
+            return u.origin;
+        } catch {
+            return '';
+        }
+    }
+}
+
+// Export for use in game.js / ui.js
+if (typeof window !== 'undefined') {
+    window.ScenarioLoader = ScenarioLoader;
+}


### PR DESCRIPTION
## Summary

Improves map rendering accuracy and adds a scenario loading system. Data is bundled statically — no runtime API calls to neobyzantine-org.

### Map rendering improvements

**`assets/geography.js`:**
- `RIVER_PATHS` restructured as objects with `width_class` (`major` / `minor`)
- New rivers: Volga, Don, Jordan, Amu Darya
- New `LAKE_POLYGONS`: Caspian Sea, Aral Sea (historical size), Lake Van, Dead Sea
- `getRiverWidthClass(lon, lat)` — returns width class for a coordinate
- `isInLake(lon, lat)` — lake tile detection; lake tiles set to height 40 in heightmap
- `isNearRiver()` updated to iterate `river.path` (breaking format change from plain arrays)

**`js/map.js`:**
- `drawRivers()` now width-aware: major rivers render 2× wider with a different blue
- Bridge overlay drawn when a road-infrastructure tile crosses a major river

### Scenario system

**`js/scenarios.js`** — new `ScenarioLoader` class:
- `loadBuiltin(id)` → `assets/scenarios/{id}.json` (primary path)
- `loadFromJson(jsonString)` → paste JSON
- `loadFromUrl(url)` → optional; restricted by exact-match allowlist (not `startsWith`)
- `applyScenario()` → centers camera, places forces on tiles
- `applyMapData()` → merges exported locations with `HISTORIC_TOWNS`

**Bundled scenarios:**
- `assets/scenarios/manzikert-1071.json` — Battle of Manzikert (1071)
- `assets/scenarios/fall-of-constantinople-1453.json` — Fall of Constantinople (1453)

**`assets/data/neobyzantine-locations.json`** — empty placeholder; updated by copying neobyzantine-org export output.

## Test plan

- [ ] Load game → rivers render: Nile/Danube/Euphrates/Tigris visually wider than Po/Rhone
- [ ] Caspian Sea area renders as inland water, not land
- [ ] `ScenarioLoader.loadBuiltin('manzikert-1071')` resolves without error
- [ ] `new Function(fs.readFileSync('js/scenarios.js', 'utf8'))` — syntax OK
- [ ] No JS console errors on game load

Addresses #46, #47, #48, #50, #51