### PR TITLE
Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,11 @@ This is a historical educational game. All historical figures and events are in 
 ---
 
 **For the Glory of Constantinople! ⚔️👑**
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/500ad.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/500ad.svg before updating the README.
- Ran git diff --check for the README change.